### PR TITLE
Fix #141: Large font accessibility issue

### DIFF
--- a/app/routes/j/$id.tsx
+++ b/app/routes/j/$id.tsx
@@ -212,7 +212,7 @@ export default function JsonDocumentRoute() {
                   </div>
                   <div className="h-screen flex flex-col sm:overflow-hidden">
                     {!loaderData.minimal && <Header />}
-                    <div className="bg-slate-50 flex-grow transition dark:bg-slate-900 overflow-y-scroll">
+                    <div className="bg-slate-50 flex-grow transition dark:bg-slate-900 overflow-y-auto">
                       <div className="main-container flex justify-items-stretch h-full">
                         <SideBar />
                         <JsonView>

--- a/app/routes/j/$id.tsx
+++ b/app/routes/j/$id.tsx
@@ -212,7 +212,7 @@ export default function JsonDocumentRoute() {
                   </div>
                   <div className="h-screen flex flex-col sm:overflow-hidden">
                     {!loaderData.minimal && <Header />}
-                    <div className="bg-slate-50 flex-grow transition dark:bg-slate-900">
+                    <div className="bg-slate-50 flex-grow transition dark:bg-slate-900 overflow-y-scroll">
                       <div className="main-container flex justify-items-stretch h-full">
                         <SideBar />
                         <JsonView>


### PR DESCRIPTION
Adding `overflow-y-scroll` to `main-container`'s wrapper seems to be fixing the issue.

<img width="1440" alt="Screenshot 2023-04-15 at 7 51 39 PM" src="https://user-images.githubusercontent.com/19573579/232230959-46a0d12b-9537-4cba-a5c3-6303384aa503.png">

Closes #141.