### PR TITLE
Fix #151: Disable input while submitting

### DIFF
--- a/app/components/UrlForm.tsx
+++ b/app/components/UrlForm.tsx
@@ -1,14 +1,16 @@
 import { useState } from "react";
-import { Form } from "remix";
+import { Form, useTransition } from "remix";
 
 export type UrlFormProps = {
   className?: string;
 };
 
 export function UrlForm({ className }: UrlFormProps) {
+  const transition = useTransition();
   const [inputValue, setInputValue] = useState("");
 
-  const isButtonDisabled = !inputValue.length;
+  const isNotIdle = transition.state !== "idle";
+  const isButtonDisabled = !inputValue.length || isNotIdle;
 
   return (
     <Form
@@ -34,7 +36,7 @@ export function UrlForm({ className }: UrlFormProps) {
           }`}
           disabled={isButtonDisabled}
         >
-          Go
+          {isNotIdle ? "..." : "Go"}
         </button>
       </div>
     </Form>


### PR DESCRIPTION
For now, I have used an ellipsis (`...`) to replace the word `Go` while submitting (This can definitely be changed to a more suitable label, if required.)
Also, I am using `transition.state !== 'idle'` because loading might also take time and we should not enable the button right after submission is completed; we should wait for the new page to load, as well.

https://user-images.githubusercontent.com/19573579/232584439-7a3bf915-12f6-4761-8b68-bdb2d9ee6dc8.mov

Closes #151.