### PR TITLE
Fixes App crash when left for a long time

### DIFF
--- a/app/components/Preview/Types/PreviewUri.tsx
+++ b/app/components/Preview/Types/PreviewUri.tsx
@@ -2,6 +2,7 @@ import { JSONStringType } from "@jsonhero/json-infer-types/lib/@types";
 import { useEffect } from "react";
 import { useFetcher } from "remix";
 import { Body } from "~/components/Primitives/Body";
+import { useNetworkState } from "~/hooks/useNetworkState";
 import { PreviewBox } from "../PreviewBox";
 import { PreviewResult } from "./preview.types";
 import { PreviewUriElement } from "./PreviewUriElement";
@@ -12,11 +13,14 @@ export type PreviewUriProps = {
 };
 
 export function PreviewUri(props: PreviewUriProps) {
-  const previewFetcher = useFetcher<PreviewResult>();
+  const { isOnline, onceOnline } = useNetworkState();
+  const previewFetcher = useFetcher < PreviewResult > ();
 
   useEffect(() => {
     const encodedUri = encodeURIComponent(props.value);
-    previewFetcher.load(`/actions/getPreview/${encodedUri}`);
+    const load = () => previewFetcher.load(`/actions/getPreview/${encodedUri}`);
+
+    isOnline ? load() : onceOnline(load);
   }, [props.value]);
 
   return (
@@ -42,7 +46,7 @@ export function PreviewUri(props: PreviewUriProps) {
       ) : (
         <PreviewBox>
           <Body className="h-96 animate-pulse bg-slate-300 dark:text-slate-300 dark:bg-slate-500 flex justify-center items-center">
-            Loading…
+            {isOnline ? "Loading…" : "No preview available (offline)"}
           </Body>
         </PreviewBox>
       )}

--- a/app/hooks/useNetworkState.tsx
+++ b/app/hooks/useNetworkState.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useNetworkState() {
+    const [isOnline, setIsOnline] = useState(window.navigator.onLine);
+    const callbackRef = useRef < () => void> ();
+
+    const on = () => {
+        setIsOnline(true);
+        callbackRef.current && callbackRef.current();
+    };
+    const off = () => setIsOnline(false);
+
+    useEffect(() => {
+        window.addEventListener("online", on);
+        window.addEventListener("offline", off);
+
+        return () => {
+            window.removeEventListener("online", on);
+            window.removeEventListener("offline", off);
+        };
+    }, []);
+
+    const onceOnline = (cb: () => void) => {
+        callbackRef.current = cb;
+    };
+
+    return { isOnline, onceOnline };
+}

--- a/app/routes/actions/getPreview.$url.ts
+++ b/app/routes/actions/getPreview.$url.ts
@@ -28,14 +28,15 @@ export const loader: LoaderFunction = async ({ params }) => {
       },
     });
   } catch {
-    const result = { error: "Unable to preview this URL" };
-
-    return new Response(JSON.stringify(result), {
-      headers: {
-        "Content-Type": "application/json; charset=utf-8",
-        "Cache-Control": "public, max-age=3600",
-      },
-    });
+    return new Response(
+      JSON.stringify({ error: "Unable to preview this URL" }),
+      {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=3600",
+        },
+      }
+    );
   }
 };
 

--- a/app/routes/actions/getPreview.$url.ts
+++ b/app/routes/actions/getPreview.$url.ts
@@ -3,29 +3,40 @@ import invariant from "tiny-invariant";
 import { getUriPreview } from "~/services/uriPreview.server";
 
 export const loader: LoaderFunction = async ({ params }) => {
-  invariant(params.url, "expected params.url");
+  try {
+    invariant(params.url, "expected params.url");
 
-  const decoded = decodeURIComponent(params.url);
+    const decoded = decodeURIComponent(params.url);
 
-  const earlyReturn = earlyRespondIfHomepagePreviewUri(decoded);
+    const earlyReturn = earlyRespondIfHomepagePreviewUri(decoded);
 
-  if (earlyReturn) {
-    return new Response(JSON.stringify(earlyReturn), {
+    if (earlyReturn) {
+      return new Response(JSON.stringify(earlyReturn), {
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "public, max-age=3600",
+        },
+      });
+    }
+
+    const result = await getUriPreview(decoded);
+
+    return new Response(JSON.stringify(result), {
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  } catch {
+    const result = { error: "Unable to preview this URL" };
+
+    return new Response(JSON.stringify(result), {
       headers: {
         "Content-Type": "application/json; charset=utf-8",
         "Cache-Control": "public, max-age=3600",
       },
     });
   }
-
-  const result = await getUriPreview(decoded);
-
-  return new Response(JSON.stringify(result), {
-    headers: {
-      "Content-Type": "application/json; charset=utf-8",
-      "Cache-Control": "public, max-age=3600",
-    },
-  });
 };
 
 function earlyRespondIfHomepagePreviewUri(uri: string) {


### PR DESCRIPTION
This closes #95.

The cause was a failing request for URL preview once the user is disconnected.

The current state of error handling with Remix doesn't allow to handle network errors manually when using `useFetcher`.

To workaround this, we detect if the user is online before loading the preview. In addition to that, errors are catched on the loader and an error response is returned.

/claim #95