### PR TITLE
fix: Ctrl+A should select all text in CodeEditor

### DIFF
--- a/app/components/CodeEditor.tsx
+++ b/app/components/CodeEditor.tsx
@@ -6,6 +6,7 @@ import {
   ViewUpdate,
 } from "@uiw/react-codemirror";
 import { useRef, useEffect } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 import { useJsonDoc } from "~/hooks/useJsonDoc";
 import { getEditorSetup } from "~/utilities/codeMirrorSetup";
 import { darkTheme, lightTheme } from "~/utilities/codeMirrorTheme";
@@ -96,20 +97,14 @@ export function CodeEditor(opts: CodeEditorProps) {
     }
   }, [selection, view, setSelectionRef.current]);
 
-  useEffect(() => {
-    const listener = (event: WindowEventMap["keydown"]) => {
-      if ((event.ctrlKey || event.metaKey) && event.key === "a") {
-        event.preventDefault();
-        view?.dispatch({ selection: { anchor: 0, head: state?.doc.length } });
-      }
-    };
-
-    window.addEventListener("keydown", listener);
-
-    return () => {
-      window.removeEventListener("keydown", listener);
-    };
-  }, [view, state]);
+  useHotkeys(
+    "ctrl+a,meta+a",
+    (e) => {
+      e.preventDefault();
+      view?.dispatch({ selection: { anchor: 0, head: state?.doc.length } });
+    },
+    [view, state]
+  );
 
   const { minimal } = useJsonDoc();
 

--- a/app/components/CodeEditor.tsx
+++ b/app/components/CodeEditor.tsx
@@ -96,6 +96,21 @@ export function CodeEditor(opts: CodeEditorProps) {
     }
   }, [selection, view, setSelectionRef.current]);
 
+  useEffect(() => {
+    const listener = (event: WindowEventMap["keydown"]) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === "a") {
+        event.preventDefault();
+        view?.dispatch({ selection: { anchor: 0, head: state?.doc.length } });
+      }
+    };
+
+    window.addEventListener("keydown", listener);
+
+    return () => {
+      window.removeEventListener("keydown", listener);
+    };
+  }, [view, state]);
+
   const { minimal } = useJsonDoc();
 
   return (


### PR DESCRIPTION
This PR adds the functionality that if `CodeEditor` is rendered on screen then `Cmd+A/Ctrl+A`  will select all the text inside `CodeEditor`.

For this solution I have added a event listener on `window`. Here a global event listener is the last option. I was not able to find a CodeMirror solution. Even if there is a CodeMirror solution we will need to enable cursor so the user knows when `Ctrl+A` will work.

/claim #162 