### PR TITLE
fix: 🐛 handle the array use case first in the stableJson util

### DIFF
--- a/app/utilities/stableJson.ts
+++ b/app/utilities/stableJson.ts
@@ -7,6 +7,11 @@ export function stableJson(json: unknown, keyOrder: string[] = []): unknown {
     const keyOrder = Object.keys(json[0]);
     return json.map((c) => stableJson(c, keyOrder));
   }
+
+  if (Array.isArray(json)) {
+    return json.map((c) => stableJson(c));
+  }
+
   if (typeof json === "object" && json !== null && keyOrder.length > 0) {
     const keys = Object.keys(json);
     const sortedKeys = keys.sort((a, b) => {
@@ -24,10 +29,6 @@ export function stableJson(json: unknown, keyOrder: string[] = []): unknown {
       result[key] = stableJson((json as Record<string, unknown>)[key]);
     }
     return result;
-  }
-
-  if (Array.isArray(json)) {
-    return json.map((c) => stableJson(c));
   }
 
   if (typeof json === "object" && json !== null) {

--- a/tests/stableJson.test.ts
+++ b/tests/stableJson.test.ts
@@ -183,3 +183,25 @@ test("It should order object keys in a similar order as the first object in an a
 }"
 `);
 });
+
+test("It should not convert an array to an object in nested arrays", () => {
+  const json = {
+    data: [
+      [1],
+      [2]
+    ],
+  };
+
+  expect(JSON.stringify(stableJson(json), null, 2)).toMatchInlineSnapshot(`
+"{
+  \\"data\\": [
+    [
+      1
+    ],
+    [
+      2
+    ]
+  ]
+}"
+`);
+});


### PR DESCRIPTION
PR to fix #174 

I moved the array handling to the start of the `stableJson` utility. The way it was previously written could result in an array falling into the `if (typeof json === "object" && json !== null && keyOrder.length > 0)` block because an array is still technically an object.