### PR TITLE
Improve error handling

### DIFF
--- a/app/routes/j/$id.tsx
+++ b/app/routes/j/$id.tsx
@@ -161,7 +161,7 @@ export const meta: MetaFunction = ({
 }) => {
   let title = "JSON Hero";
 
-  if (data) {
+  if (data?.doc?.title) {
     title += ` - ${data.doc.title}`;
   }
 


### PR DESCRIPTION
When JSON Hero fails to fetch a json for some reason it throws an error, which is outside of any catch/error boundary.
In this case `safeFetch` returns a response with HTTP status 520 send from the remote server.

<img width="1485" alt="Screenshot 2024-06-01 at 16 24 16" src="https://github.com/triggerdotdev/jsonhero-web/assets/63966/bd2afd63-f019-458f-b75e-689aaac87702">

The first commit fixes this problem:
[fix: don't try to access the title if doc is undefined](https://github.com/triggerdotdev/jsonhero-web/commit/ebdeb78a3baea809a511f18c41a264f3060a36c4)

The second adds the display of the actual errors coming from `safeFetch`:
[fix: show the fetch errors when thrown, instead of hardcoded 404](https://github.com/triggerdotdev/jsonhero-web/commit/acaea20aa96d3cd575238c06275b16542c95697f)